### PR TITLE
fix(client): Client side couldn't resolve uuid module

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,7 @@
     "rimraf": "^3.0.2",
     "typescript": "^4.3.4"
   },
-  "dependencies": {
-    "uuid": "^8.3.2"
-  },
+  "dependencies": {},
   "repository": {
     "type": "git",
     "url": "git+https://github.com/project-error/pe-utils.git"

--- a/src/client/cl_utils.ts
+++ b/src/client/cl_utils.ts
@@ -1,6 +1,15 @@
-import { v4 as uuidv4 } from "uuid";
 import { ClientUtilSettings, ClientUtilsParams, NuiCallbackFunc, RPCListenerCb } from "../types";
 
+/**
+ * Returns a Universal Unique identifier
+ * @returns string
+ */
+function uuidv4(): string {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+        const r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+        return v.toString(16);
+    });
+}
 
 export class ClientUtils {
   private _settings: ClientUtilSettings = {

--- a/src/server/sv_utils.ts
+++ b/src/server/sv_utils.ts
@@ -1,5 +1,4 @@
 import { ServerErrorCodes, ServerStatus } from "../misc";
-import { v4 as uuidv4 } from "uuid";
 
 import {
   CBSignature,
@@ -9,6 +8,16 @@ import {
   ServerUtilSettings
 } from "../types";
 
+/**
+ * Returns a Universal Unique identifier
+ * @returns string
+ */
+function uuidv4(): string {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+        const r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+        return v.toString(16);
+    });
+}
 
 export class ServerUtils {
   private readonly _utilSettings: ServerUtilSettings = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1373,11 +1373,6 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
 v8-compile-cache@^2.0.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"


### PR DESCRIPTION
When using the module on the client-side, the script using pe-utils keeps crashing because require isn't allowed on client side scripts. So by creating a local uuidv4 function and ditching the uuid module we fix the external module problem on the client side.
![image](https://user-images.githubusercontent.com/19311856/136000639-c43bb164-9f0d-425f-90d0-6c46281a6ca1.png)
![image](https://user-images.githubusercontent.com/19311856/136000660-39efcaca-fe49-465b-9340-8142d887d89a.png)
